### PR TITLE
feat: add command to list all branches of user

### DIFF
--- a/internal/cmd/client.go
+++ b/internal/cmd/client.go
@@ -70,6 +70,8 @@ func (c *githubClient) DeleteWorkflowRuns(ctx context.Context, runs []*github.Wo
 	return nil
 }
 
+// getBranches returns all branches with the last commit being authored by the specified author.
+// Limit is the per-page limit for the GitHub API. (capped at 100)
 func (c *githubClient) GetBranches(ctx context.Context, author string, limit int) ([]*github.Branch, error) {
 	if limit > 100 {
 		// max limit as per https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28

--- a/internal/cmd/listbranches.go
+++ b/internal/cmd/listbranches.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/katexochen/ghh/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+// NewListBranchesCmd creates a new command for listing all GitHub branches of the authenticated user.
+func NewListBranchesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-branches",
+		Short: "List all branches where the last commit has been pushed by the authenticated user",
+		RunE:  listBranches,
+	}
+	return cmd
+}
+
+func listBranches(cmd *cobra.Command, _ []string) error {
+	flags, err := parseListBranchesFlags(cmd)
+	if err != nil {
+		return fmt.Errorf("get current repository: %w", err)
+	}
+
+	var log loggerI
+	if flags.verbose {
+		log = &logger.VerboseLogger{}
+	} else {
+		log = &logger.DefaultLogger{}
+	}
+
+	owner, repo, err := findOwnerAndRepo()
+	if err != nil {
+		return fmt.Errorf("get current repository: %w", err)
+	}
+
+	token, err := getToken()
+	if err != nil {
+		return fmt.Errorf("get personal access token: %w", err)
+	}
+
+	c := newGithubClient(cmd.Context(), owner, repo, token)
+
+	user, err := c.GetUser(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("get user: %w", err)
+	}
+	log.PrintJSON("user", user)
+
+	branches, err := c.GetBranches(cmd.Context(), user.GetLogin(), 50)
+	if err != nil {
+		return fmt.Errorf("get branches: %w", err)
+	}
+	log.PrintJSON("branches", branches)
+
+	if len(branches) == 0 {
+		cmd.Println("No branches found")
+		return nil
+	}
+
+	cmd.Println("Your branches:")
+	for _, b := range branches {
+		cmd.Printf("\t%s - %s\n", b.GetName(), b.GetCommit().GetSHA())
+	}
+	return nil
+}
+
+type listBranchesFlags struct {
+	verbose bool
+}
+
+func parseListBranchesFlags(cmd *cobra.Command) (listBranchesFlags, error) {
+	verbose, err := cmd.Flags().GetBool("verbose")
+	if err != nil {
+		return listBranchesFlags{}, fmt.Errorf("parse verbose flag: %w", err)
+	}
+
+	return listBranchesFlags{
+		verbose: verbose,
+	}, nil
+}

--- a/internal/cmd/listbranches.go
+++ b/internal/cmd/listbranches.go
@@ -48,7 +48,7 @@ func listBranches(cmd *cobra.Command, _ []string) error {
 	}
 	log.PrintJSON("user", user)
 
-	branches, err := c.GetBranches(cmd.Context(), user.GetLogin(), 50)
+	branches, err := c.GetBranches(cmd.Context(), user.GetLogin(), 100)
 	if err != nil {
 		return fmt.Errorf("get branches: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewDeleteAllRunsCmd(),
 		cmd.NewCreateProjectIssueCmd(),
 		cmd.NewSetAuthCmd(),
+		cmd.NewListBranchesCmd(),
 	)
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 


### PR DESCRIPTION
## Proposed changes
- Add a command to list all branches of a user. Optimal if you are in a stressful office and only have 5 seconds to show something to your colleagues

## Follow-ups
- Improve performance and add sanity checks. Right now, this has a complexity of O(n) for a repository with n branches
  - https://github.com/edgelesssys/constellation/branches/yours is a lot faster but I didn't find a corresponding API endpoint 