### PR TITLE
Fix config file permissions to protect token

### DIFF
--- a/internal/cmd/setauth.go
+++ b/internal/cmd/setauth.go
@@ -55,7 +55,7 @@ func setupAuth(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(configDir, configFilePath), file, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(configDir, configFilePath), file, 0o600); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The config file was previously readable by other users, exposing the token to them.