### PR TITLE
sync-forks: fix usage of default branch

### DIFF
--- a/internal/cmd/syncfork.go
+++ b/internal/cmd/syncfork.go
@@ -86,7 +86,7 @@ func syncForks(cmd *cobra.Command, _ []string) error {
 	for _, fork := range forks {
 		var branch string
 		if !flags.dontTargetDefault {
-			branch := fork.GetDefaultBranch()
+			branch = fork.GetDefaultBranch()
 			log.Debugf("%s: default branch is %s", fork.GetFullName(), branch)
 		}
 


### PR DESCRIPTION
The bug caused the default branche not be picked, resulting in no sync if the default branch would be the target.